### PR TITLE
Callback generate video

### DIFF
--- a/config/trajectory_editing_adam.yml
+++ b/config/trajectory_editing_adam.yml
@@ -6,7 +6,12 @@ dno:
   optimizer: Adam # Adam, SGD, LBFGS, LevenbergMarquardt, ...
   lr: 5e-2 # Default
 extra_callbacks:
+  # - name: early_stopping
+  #   args:
+  #     patience: 200
+  #     min_improvement: 0
+  #     abs_value: 5e-5
   - name: profiler
   - name: generate_video
     args:
-      every_n_steps: 50
+      every_n_steps: 10

--- a/config/trajectory_editing_adam.yml
+++ b/config/trajectory_editing_adam.yml
@@ -7,3 +7,6 @@ dno:
   lr: 5e-2 # Default
 extra_callbacks:
   - name: profiler
+  - name: generate_video
+    args:
+      every_n_steps: 5

--- a/config/trajectory_editing_adam.yml
+++ b/config/trajectory_editing_adam.yml
@@ -6,12 +6,42 @@ dno:
   optimizer: Adam # Adam, SGD, LBFGS, LevenbergMarquardt, ...
   lr: 5e-2 # Default
 extra_callbacks:
-  # - name: early_stopping
-  #   args:
-  #     patience: 200
-  #     min_improvement: 0
-  #     abs_value: 5e-5
+  - name: early_stopping
+    args:
+      patience: 250
+      min_improvement: 0
+      abs_value: 1e-5
   - name: profiler
   - name: generate_video
     args:
-      every_n_steps: 10
+      schedule:
+        [
+          10,
+          20,
+          30,
+          40,
+          41,
+          42,
+          43,
+          44,
+          45,
+          46,
+          47,
+          48,
+          49,
+          50,
+          55,
+          60,
+          65,
+          70,
+          100,
+          150,
+          200,
+          250,
+          300,
+          400,
+          500,
+          600,
+          800,
+          1000,
+        ]

--- a/config/trajectory_editing_adam.yml
+++ b/config/trajectory_editing_adam.yml
@@ -9,4 +9,4 @@ extra_callbacks:
   - name: profiler
   - name: generate_video
     args:
-      every_n_steps: 5
+      every_n_steps: 50

--- a/dno_optimized/callbacks/callback.py
+++ b/dno_optimized/callbacks/callback.py
@@ -79,8 +79,11 @@ class Callback(ABC):
         pass
 
     def _should_run_step_callback(self):
+        # 1-based modulo, 0-based start-after
+        # Example:
+        # On 12 iterations, with start_after=3 and every_n_steps=3, would execute on steps (0-based) 5, 8, 11 (2 is skipped)
         step = self.dno.step_count
-        return step >= self.start_after and (step % self.every_n_steps) == 0
+        return step >= self.start_after and ((step + 1) % self.every_n_steps) == 0
 
     def invoke(
         self, callback_stage: Literal["train_begin", "train_end", "step_begin", "step_end"], **kwargs

--- a/dno_optimized/callbacks/callback.py
+++ b/dno_optimized/callbacks/callback.py
@@ -79,11 +79,8 @@ class Callback(ABC):
         pass
 
     def _should_run_step_callback(self):
-        # 1-based modulo, 0-based start-after
-        # Example:
-        # On 12 iterations, with start_after=3 and every_n_steps=3, would execute on steps (0-based) 5, 8, 11 (2 is skipped)
         step = self.dno.step_count
-        return step >= self.start_after and ((step + 1) % self.every_n_steps) == 0
+        return step > self.start_after and (step  % self.every_n_steps) == 0
 
     def invoke(
         self, callback_stage: Literal["train_begin", "train_end", "step_begin", "step_end"], **kwargs

--- a/dno_optimized/callbacks/early_stopping.py
+++ b/dno_optimized/callbacks/early_stopping.py
@@ -24,7 +24,7 @@ class EarlyStoppingCallback(Callback):
         self.min_improvement = min_improvement
         self.mode = mode
         self.metric = metric
-        self.abs_value = abs_value
+        self.abs_value = float(abs_value) if abs_value is not None else None
 
         # State
         self._best_value: float = float("inf") if mode == "min" else float("-inf")

--- a/dno_optimized/callbacks/early_stopping.py
+++ b/dno_optimized/callbacks/early_stopping.py
@@ -39,8 +39,6 @@ class EarlyStoppingCallback(Callback):
             mode=config.get("mode", "min"),
             metric=config.get("metric", "loss"),
             abs_value=config.get("abs_value"),
-            every_n_steps=config.get("every_n_steps"),
-            start_after=config.get("start_after"),
         )
 
     @override

--- a/dno_optimized/callbacks/generate_video.py
+++ b/dno_optimized/callbacks/generate_video.py
@@ -27,7 +27,6 @@ class GenerateVideoCallback(Callback):
         return cls(
             out_dir=config.get("out_dir", options.out_path / "intermediate_videos"),
             every_n_steps=config.get("every_n_steps", 10),  # Override default
-            start_after=config.get("start_after"),
         )
 
     def on_step_end(self, step: int, info: DNOInfoDict, hist: list[DNOInfoDict]) -> CallbackStepAction | None:

--- a/dno_optimized/callbacks/generate_video.py
+++ b/dno_optimized/callbacks/generate_video.py
@@ -1,0 +1,46 @@
+import warnings
+from pathlib import Path
+from typing import Callable, Self, override
+
+from dno_optimized.callbacks.callback import CallbackList, CallbackStepAction
+from dno_optimized.noise_optimizer import DNOInfoDict
+from dno_optimized.options import GenerateOptions
+
+from .callback import Callback
+
+
+class GenerateVideoCallback(Callback):
+    def __init__(self, out_dir: str = "videos", every_n_steps: int | None = None, start_after: int | None = None):
+        super().__init__(every_n_steps, start_after)
+
+        self.out_dir = Path(out_dir)
+
+        self.process_fn: Callable | None = None
+
+    def __post_init__(self, callbacks: CallbackList, process_fn: Callable):
+        # Get the result processing function from main function
+        self.process_fn = process_fn
+
+    @override
+    @classmethod
+    def from_config(cls, options: GenerateOptions, config: dict) -> Self:
+        return cls(
+            out_dir=config.get("out_dir", options.out_path / "intermediate_videos"),
+            every_n_steps=config.get("every_n_steps", 10), # Override default
+            start_after=config.get("start_after"),
+        )
+
+    def on_step_end(self, step: int, info: DNOInfoDict, hist: list[DNOInfoDict]) -> CallbackStepAction | None:
+        if self.process_fn is None:
+            warnings.warn(
+                "Using GenerateVideo callback, but process_fn was not passed. "
+                "Please pass the output processing function to callbacks.post_init(...)"
+            )
+            return
+
+        # Get current output
+        out = self.dno.state_dict()
+
+        # Visualize
+        self.out_dir.mkdir(parents=True, exist_ok=True)
+        self.process_fn(out, save=False, plots=False, videos=True, out_dir=str(self.out_dir))

--- a/dno_optimized/callbacks/generate_video.py
+++ b/dno_optimized/callbacks/generate_video.py
@@ -26,7 +26,7 @@ class GenerateVideoCallback(Callback):
     def from_config(cls, options: GenerateOptions, config: dict) -> Self:
         return cls(
             out_dir=config.get("out_dir", options.out_path / "intermediate_videos"),
-            every_n_steps=config.get("every_n_steps", 10), # Override default
+            every_n_steps=config.get("every_n_steps", 10),  # Override default
             start_after=config.get("start_after"),
         )
 
@@ -38,9 +38,11 @@ class GenerateVideoCallback(Callback):
             )
             return
 
+        self.progress.write("Saving intermedaite video")
+
         # Get current output
         out = self.dno.state_dict()
 
         # Visualize
         self.out_dir.mkdir(parents=True, exist_ok=True)
-        self.process_fn(out, save=False, plots=False, videos=True, out_dir=str(self.out_dir))
+        self.process_fn(out, save=False, plots=False, videos=True, step=step, out_dir=str(self.out_dir))

--- a/dno_optimized/callbacks/profiler.py
+++ b/dno_optimized/callbacks/profiler.py
@@ -46,8 +46,6 @@ class ProfilerCallback(Callback):
     def from_config(cls, options: GenerateOptions, config: dict) -> Self:
         return cls(
             report_dir=config.get("report_dir") or str(options.out_path / "profiler"),
-            every_n_steps=config.get("every_n_steps"),
-            start_after=config.get("start_after"),
         )
 
     def _log(self, global_step: int, key: str, value: float | int, tb_tag: str | None = None):

--- a/dno_optimized/callbacks/save_top_k.py
+++ b/dno_optimized/callbacks/save_top_k.py
@@ -44,7 +44,7 @@ class ModelCheckpoint:
     step: int
     metric_name: str
     metric_value: float
-    state_dict: dict
+    state_dict: DNOStateDict
     type: Literal["best", "latest"]
 
     def get_save_path(self, save_dir: Path):
@@ -91,8 +91,6 @@ class SaveTopKCallback(Callback):
             mode=config.get("mode", "min"),
             save_latest=config.get("save_latest", True),
             flush_every=config.get("flush_every", 10),
-            every_n_steps=config.get("every_n_steps"),
-            start_after=config.get("start_after"),
         )
 
     @property

--- a/dno_optimized/generate.py
+++ b/dno_optimized/generate.py
@@ -595,9 +595,9 @@ def save_videos(
         sample_file_template,
         row_file_template,
         all_file_template,
-    ) = construct_template_variables(args.unconstrained)
+    ) = construct_template_variables(args.unconstrained, step=on_step)
 
-    for sample_i in tqdm(range(args.num_samples), ncols=0, dynamic_ncols=False, desc="Saving videos"):
+    for sample_i in (pb := tqdm(range(args.num_samples), ncols=0, dynamic_ncols=False, desc="Saving videos")):
         rep_files = []
 
         caption = all_text[sample_i]
@@ -605,7 +605,7 @@ def save_videos(
         motion = all_motions[sample_i].transpose(2, 0, 1)[:length]
         save_file = sample_file_template.format(*(([on_step] if on_step else []) + [0, sample_i]))
         if verbose:
-            print(sample_print_template.format(caption, 0, sample_i, save_file))
+            pb.write(sample_print_template.format(caption, 0, sample_i, save_file))
         animation_save_path = os.path.join(out_dir, save_file)
         plot_3d_motion(
             animation_save_path,
@@ -634,6 +634,7 @@ def save_videos(
             rep_files,
             sample_files,
             sample_i,
+            on_step=on_step
         )
 
     abs_path = os.path.abspath(out_dir)

--- a/dno_optimized/generate.py
+++ b/dno_optimized/generate.py
@@ -597,7 +597,10 @@ def save_videos(
         all_file_template,
     ) = construct_template_variables(args.unconstrained, step=on_step)
 
-    for sample_i in (pb := tqdm(range(args.num_samples), ncols=0, dynamic_ncols=False, desc="Saving videos")):
+    pb = None
+    if verbose:
+        pb = tqdm(total=args.num_samples, ncols=0, dynamic_ncols=False, desc="Saving videos")
+    for sample_i in range(args.num_samples):
         rep_files = []
 
         caption = all_text[sample_i]
@@ -636,8 +639,11 @@ def save_videos(
             sample_i,
             on_step=on_step,
             verbose=verbose,
-            delete_originals=True
+            delete_originals=True,
         )
+
+        if pb is not None:
+            pb.update(1)
 
     abs_path = os.path.abspath(out_dir)
     if verbose:

--- a/dno_optimized/generate.py
+++ b/dno_optimized/generate.py
@@ -607,7 +607,7 @@ def save_videos(
         length = all_lengths[sample_i]
         motion = all_motions[sample_i].transpose(2, 0, 1)[:length]
         save_file = sample_file_template.format(*(([on_step] if on_step else []) + [0, sample_i]))
-        if verbose:
+        if pb is not None:
             pb.write(sample_print_template.format(caption, 0, sample_i, save_file))
         animation_save_path = os.path.join(out_dir, save_file)
         plot_3d_motion(

--- a/dno_optimized/generate.py
+++ b/dno_optimized/generate.py
@@ -444,7 +444,7 @@ def process_results(
     step_out_list = [int(aa * stop_optimize) for aa in step_out_list]
     step_out_list[-1] = stop_optimize - 1
 
-    for t in tqdm(step_out_list, ncols=0, dynamic_ncols=False, desc="Saving results"):
+    for t in step_out_list:
         # aggregate the batch
         inter_step = []
         for i in range(args.num_trials):
@@ -634,7 +634,9 @@ def save_videos(
             rep_files,
             sample_files,
             sample_i,
-            on_step=on_step
+            on_step=on_step,
+            verbose=verbose,
+            delete_originals=True
         )
 
     abs_path = os.path.abspath(out_dir)

--- a/dno_optimized/noise_optimizer.py
+++ b/dno_optimized/noise_optimizer.py
@@ -152,12 +152,11 @@ class DNO:
 
         batch_size = self.start_z.shape[0]
 
-        self.step_count = 0
+        self.step_count = 1
         self.callbacks.invoke(self, "train_begin", num_steps=num_steps, batch_size=batch_size)
 
         pb = tqdm(total=num_steps)
         for i in range(num_steps):
-            assert self.step_count == i
 
             def closure():
                 # Reset gradients
@@ -189,7 +188,7 @@ class DNO:
             self.step_count += 1
 
         # Check for early stopping
-        if self.step_count != num_steps - 1:
+        if self.step_count != num_steps:
             print(f"INFO: Stopping optimization early at step {self.step_count}/{num_steps}")
 
         hist = self.compute_hist(batch_size=batch_size)

--- a/dno_optimized/noise_optimizer.py
+++ b/dno_optimized/noise_optimizer.py
@@ -92,7 +92,7 @@ class DNO:
     def __init__(
         self,
         model,
-        criterion: Callable[[Tensor], float],
+        criterion: Callable[[Tensor], Tensor],
         start_z: Tensor,
         conf: DNOOptions,
         callbacks: "CallbackList | None" = None,
@@ -165,7 +165,7 @@ class DNO:
                 self.optimizer.zero_grad()
                 # Single step forward and backward
                 self.last_x, loss = self.compute_loss(batch_size=batch_size)
-                return loss
+                return loss.item()
 
             # Pre-step callbacks
             res = self.callbacks.invoke(self, "step_begin", pb=pb, step=i)
@@ -268,6 +268,7 @@ class DNO:
         loss.backward()
 
         # log grad norm (before)
+        assert self.current_z.grad is not None
         self.info["grad_norm"] = self.current_z.grad.norm(p=2, dim=self.dims).detach().cpu()
 
         # grad mode

--- a/utils/callback_util.py
+++ b/utils/callback_util.py
@@ -61,7 +61,7 @@ def callback_list_from_config(configs: list[CallbackConfig], options: GenerateOp
     return cb_list
 
 
-def callbacks_from_options(options: GenerateOptions):
+def callbacks_from_options(options: GenerateOptions, post_init_kwargs: dict | None = None):
     """Instantiate all callbacks using `callbacks` (if present), else default callbacks, and merging with `extra_callbacks`.
 
     :param options: Global generate options
@@ -74,5 +74,5 @@ def callbacks_from_options(options: GenerateOptions):
     )
     if options.extra_callbacks:
         callbacks.extend(callback_list_from_config(options.extra_callbacks, options), mode="replace")
-    callbacks.post_init()
+    callbacks.post_init(**(post_init_kwargs or {}))
     return callbacks

--- a/utils/callback_util.py
+++ b/utils/callback_util.py
@@ -16,19 +16,23 @@ def create_callback(name: str, options: GenerateOptions, callback_args: dict) ->
     :raises KeyError: The provided callback is not registered.
     :return: Instantiated callback
     """
+    callback = None
     match name:
         case "tensorboard":
-            return TensorboardCallback.from_config(options, callback_args)
+            callback = TensorboardCallback.from_config(options, callback_args)
         case "early_stopping":
-            return EarlyStoppingCallback.from_config(options, callback_args)
+            callback = EarlyStoppingCallback.from_config(options, callback_args)
         case "save_top_k":
-            return SaveTopKCallback.from_config(options, callback_args)
+            callback = SaveTopKCallback.from_config(options, callback_args)
         case "profiler":
-            return ProfilerCallback.from_config(options, callback_args)
+            callback = ProfilerCallback.from_config(options, callback_args)
         case "generate_video":
-            return GenerateVideoCallback.from_config(options, callback_args)
+            callback = GenerateVideoCallback.from_config(options, callback_args)
         case _:
             raise KeyError(f"`{name}` is not a valid callback name")
+    # Set common options
+    callback.init_from_config(options, callback_args)
+    return callback
 
 
 def default_callbacks(options: GenerateOptions, run_post_init: bool = False) -> CallbackList:

--- a/utils/callback_util.py
+++ b/utils/callback_util.py
@@ -1,5 +1,6 @@
 from dno_optimized.callbacks.callback import Callback, CallbackList
 from dno_optimized.callbacks.early_stopping import EarlyStoppingCallback
+from dno_optimized.callbacks.generate_video import GenerateVideoCallback
 from dno_optimized.callbacks.profiler import ProfilerCallback
 from dno_optimized.callbacks.save_top_k import SaveTopKCallback
 from dno_optimized.callbacks.tensorboard import TensorboardCallback
@@ -24,11 +25,13 @@ def create_callback(name: str, options: GenerateOptions, callback_args: dict) ->
             return SaveTopKCallback.from_config(options, callback_args)
         case "profiler":
             return ProfilerCallback.from_config(options, callback_args)
+        case "generate_video":
+            return GenerateVideoCallback.from_config(options, callback_args)
         case _:
             raise KeyError(f"`{name}` is not a valid callback name")
 
 
-def default_callbacks(options: GenerateOptions, run_post_init: bool = True) -> CallbackList:
+def default_callbacks(options: GenerateOptions, run_post_init: bool = False) -> CallbackList:
     """Get a list of default callbacks.
 
     :param options: Global generate options
@@ -47,7 +50,7 @@ def default_callbacks(options: GenerateOptions, run_post_init: bool = True) -> C
     return cb_list
 
 
-def callback_list_from_config(configs: list[CallbackConfig], options: GenerateOptions, run_post_init: bool = True):
+def callback_list_from_config(configs: list[CallbackConfig], options: GenerateOptions, run_post_init: bool = False):
     """Create a callback list from a list of callback configurations
 
     :param configs: List of callback configs
@@ -68,9 +71,7 @@ def callbacks_from_options(options: GenerateOptions, post_init_kwargs: dict | No
     :return: Callback list
     """
     callbacks = (
-        callback_list_from_config(options.callbacks, options, run_post_init=False)
-        if options.callbacks
-        else default_callbacks(options, run_post_init=False)
+        callback_list_from_config(options.callbacks, options) if options.callbacks else default_callbacks(options)
     )
     if options.extra_callbacks:
         callbacks.extend(callback_list_from_config(options.extra_callbacks, options), mode="replace")

--- a/utils/output_util.py
+++ b/utils/output_util.py
@@ -1,4 +1,5 @@
 import os
+
 import numpy as np
 
 from data_loaders.humanml.scripts.motion_process import recover_from_ric
@@ -65,18 +66,18 @@ def sample_to_motion(sample_list, args, model_kwargs, model, n_frames,
     return all_motions, all_lengths, all_text
 
 
-def construct_template_variables(unconstrained):
+def construct_template_variables(unconstrained, step: int | None = None):
     row_file_template = 'sample{:02d}.mp4'
     all_file_template = 'samples_{:02d}_to_{:02d}.mp4'
     if unconstrained:
-        sample_file_template = 'row{:02d}_col{:02d}.mp4'
+        sample_file_template = ('step{:04d}_' if step else '') + 'row{:02d}_col{:02d}.mp4'
         sample_print_template = '[{} row #{:02d} column #{:02d} | -> {}]'
         row_file_template = row_file_template.replace('sample', 'row')
         row_print_template = '[{} row #{:02d} | all columns | -> {}]'
         all_file_template = all_file_template.replace('samples', 'rows')
         all_print_template = '[rows {:02d} to {:02d} | -> {}]'
     else:
-        sample_file_template = 'sample{:02d}_rep{:02d}.mp4'
+        sample_file_template = ('step{:04d}_' if step else '') + 'sample{:02d}_rep{:02d}.mp4'
         sample_print_template = '["{}" ({:02d}) | Rep #{:02d} | -> {}]'
         row_print_template = '[ "{}" ({:02d}) | all repetitions | -> {}]'
         all_print_template = '[samples {:02d} to {:02d} | all repetitions | -> {}]'
@@ -105,7 +106,7 @@ def save_multiple_samples(args, out_path, row_print_template,
         ffmpeg_rep_files = [f' -i {f} ' for f in sample_files]
         vstack_args = f' -filter_complex hstack=inputs={len(sample_files)}' if len(
             sample_files) > 1 else ''
-        ffmpeg_rep_cmd = f'ffmpeg -y -loglevel warning ' + ''.join(
+        ffmpeg_rep_cmd = 'ffmpeg -y -loglevel warning ' + ''.join(
             ffmpeg_rep_files) + f'{vstack_args} {all_sample_save_path}'
         os.system(ffmpeg_rep_cmd)
         sample_files = []
@@ -161,8 +162,8 @@ def vis_fn(sample, filename, data, model, concat=False, abs_3d=False, traj_only=
         all_rep_save_path = os.path.join(out_path, "log_dump",
                                             "compare.mp4")
         ffmpeg_rep_files = [f' -i {f} ' for f in name_list]
-        hstack_args = f' -filter_complex hstack=inputs=2'
-        ffmpeg_rep_cmd = f'ffmpeg -y -loglevel warning ' + ''.join(
+        hstack_args = ' -filter_complex hstack=inputs=2'
+        ffmpeg_rep_cmd = 'ffmpeg -y -loglevel warning ' + ''.join(
             ffmpeg_rep_files) + f'{hstack_args} {all_rep_save_path}'
         os.system(ffmpeg_rep_cmd)
         # print(row_print_template.format(caption, sample_i, all_rep_save_file))

--- a/utils/output_util.py
+++ b/utils/output_util.py
@@ -68,16 +68,16 @@ def sample_to_motion(sample_list, args, model_kwargs, model, n_frames,
 
 def construct_template_variables(unconstrained, step: int | None = None):
     row_file_template = 'sample{:02d}.mp4'
-    all_file_template = 'samples_{:02d}_to_{:02d}.mp4'
+    all_file_template = ('step{:04d}_' if step is not None else '') + 'samples_{:02d}_to_{:02d}.mp4'
     if unconstrained:
-        sample_file_template = ('step{:04d}_' if step else '') + 'row{:02d}_col{:02d}.mp4'
+        sample_file_template = ('step{:04d}_' if step is not None else '') + 'row{:02d}_col{:02d}.mp4'
         sample_print_template = '[{} row #{:02d} column #{:02d} | -> {}]'
         row_file_template = row_file_template.replace('sample', 'row')
         row_print_template = '[{} row #{:02d} | all columns | -> {}]'
         all_file_template = all_file_template.replace('samples', 'rows')
         all_print_template = '[rows {:02d} to {:02d} | -> {}]'
     else:
-        sample_file_template = ('step{:04d}_' if step else '') + 'sample{:02d}_rep{:02d}.mp4'
+        sample_file_template = ('step{:04d}_' if step is not None else '') + 'sample{:02d}_rep{:02d}.mp4'
         sample_print_template = '["{}" ({:02d}) | Rep #{:02d} | -> {}]'
         row_print_template = '[ "{}" ({:02d}) | all repetitions | -> {}]'
         all_print_template = '[samples {:02d} to {:02d} | all repetitions | -> {}]'
@@ -89,7 +89,7 @@ def construct_template_variables(unconstrained, step: int | None = None):
 def save_multiple_samples(args, out_path, row_print_template,
                           all_print_template, row_file_template,
                           all_file_template, caption, num_samples_in_out_file,
-                          rep_files, sample_files, sample_i):
+                          rep_files, sample_files, sample_i, on_step):
 
     sample_files.append(rep_files[0])
 
@@ -98,7 +98,7 @@ def save_multiple_samples(args, out_path, row_print_template,
         # if (sample_i + 1) % num_samples_in_out_file == 0 or sample_i + 1 == args.num_repetitions:
         # all_sample_save_file =  f'samples_{(sample_i - len(sample_files) + 1):02d}_to_{sample_i:02d}.mp4'
         all_sample_save_file = all_file_template.format(
-            sample_i - len(sample_files) + 1, sample_i)
+            *(([on_step] if on_step is not None else []) + [sample_i - len(sample_files) + 1, sample_i]))
         all_sample_save_path = os.path.join(out_path, all_sample_save_file)
         print(
             all_print_template.format(sample_i - len(sample_files) + 1,


### PR DESCRIPTION
Callback that generates videos for visualization from the current state of training.

The callback can be configured either with

- `every_n_steps` -- To run every $n$ steps
- `schedule` -- To run on particular steps.

The latter is particularly useful if you know approximately at which step there is most change. You can infer that from the loss curve after training once.

**Note:** This callback required major restructuring of the original DNO code. The `generate.py` script was heavily modified to make functions more modular and remove useless functionality.